### PR TITLE
Remove GH link in navbar

### DIFF
--- a/_includes/default-header.html
+++ b/_includes/default-header.html
@@ -40,11 +40,6 @@
             {% endfor %}
           </div>
         </div>
-
-        <a class="navbar-item" href="{{ site.github.repository_url }}">
-          <span class="icon"> <i class="fab fa-github"></i> </span> &nbsp; View
-          on GitHub
-        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
We have this link in the footer already (2 times). I don't think people are interested in the GH repo.