### PR TITLE
Update of github project URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ In the sequel, we assume you use miniconda.
 2. Clone this GitHub repository:
 
    ```
-   git clone https://github.com/StreetScienceCommunity/StreetScienceCommunity.git
+   git clone https://github.com/StreetScienceCommunity/StreetScienceCommunity.github.io
    ```
 
-3. Navigate to the `StreetScienceCommunity/` folder with `cd`
+3. Navigate to the `StreetScienceCommunity.github.io/` folder with `cd`
 4. Set up the conda environment:
 
    ```


### PR DESCRIPTION
The URL mentioned does not exist. The .git suffix is not required.

My had thought I could quickly propose some magic lines that would allow the installation without conda on some throwaway VM on which one would have root access.  I am stuck at
```
/usr/lib/ruby/vendor_ruby/jekyll/drops/document_drop.rb:8: warning: previous definition of NESTED_OBJECT_FIELD_BLACKLIST was here
/var/lib/gems/2.5.0/gems/jekyll-3.8.5/lib/jekyll/drops/drop.rb:8: warning: already initialized constant Jekyll::Drops::Drop::NON_CONTENT_METHODS
/usr/lib/ruby/vendor_ruby/jekyll/drops/drop.rb:8: warning: previous definition of NON_CONTENT_METHODS was here
Configuration file: /home/moeller/github/StreetScienceCommunity.github.io/_config.yml
            Source: /home/moeller/github/StreetScienceCommunity.github.io
       Destination: /home/moeller/github/StreetScienceCommunity.github.io/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
                    done in 4.92 seconds.
jekyll 3.8.3 | Error:  uninitialized constant FFI::Platform::CPU
```
I somehow find all that ruby/gem/bundel/jekyll business to be very delicate. 